### PR TITLE
BUGFIX : nested exception when jruby exception gets raised

### DIFF
--- a/models/api.rb
+++ b/models/api.rb
@@ -48,9 +48,7 @@ module GitlabWebHook
       status 404
       e.message
     rescue => e
-      # avoid method signature warnings
-      severe = LOGGER.java_method(:log, [Level, java.lang.String, java.lang.Throwable])
-      severe.call(Level::SEVERE, e.message, e)
+      LOGGER.severe "#{e.message}\n    #{e.backtrace.join("\n    ")}"
       status 500
       e.message
     end


### PR DESCRIPTION
When an exception on GitSCM.new happens, an exception occurs within the rescue block:

```
TypeError - cannot convert instance of class org.jruby.RubyException to class java.lang.Throwable
```
