### PR TITLE
Schedule build only if project polling detects changes

### DIFF
--- a/models/use_cases/build_now.rb
+++ b/models/use_cases/build_now.rb
@@ -6,6 +6,7 @@ include Java
 
 java_import Java.java.util.logging.Logger
 java_import Java.java.util.logging.Level
+java_import Java.hudson.util.StreamTaskListener
 
 module GitlabWebHook
   class BuildNow
@@ -25,6 +26,8 @@ module GitlabWebHook
       raise ArgumentError.new('details are required') unless details
 
       begin
+        poll_result = project.poll StreamTaskListener.new()
+        return "No SMC changes on #{project}" unless poll_result.has_changes?
         return "#{project} scheduled for build" if project.scheduleBuild2(project.getQuietPeriod(), cause_builder.with(details), actions_builder.with(project, details))
       rescue java.lang.Exception => e
         # avoid method signature warnings

--- a/models/values/project.rb
+++ b/models/values/project.rb
@@ -15,7 +15,7 @@ module GitlabWebHook
   class Project
     extend Forwardable
 
-    def_delegators :@jenkins_project, :scm, :schedulePolling, :scheduleBuild2, :fullName, :isParameterized, :isBuildable, :getQuietPeriod, :getProperty, :delete, :description
+    def_delegators :@jenkins_project, :scm, :schedulePolling, :scheduleBuild2, :fullName, :isParameterized, :isBuildable, :getQuietPeriod, :getProperty, :delete, :description, :poll
 
     alias_method :parametrized?, :isParameterized
     alias_method :buildable?, :isBuildable


### PR DESCRIPTION
This avoids to build jobs that should be prevented by advanced git plugin configuration, such as directory exclusion.
