### PR TITLE
Sample payloads

### DIFF
--- a/spec/fixtures/default_params.json
+++ b/spec/fixtures/default_params.json
@@ -1,7 +1,7 @@
 {
     "ref": "refs/heads/master",
-    "repo_url": "http://localhost/peronospora",
+    "repo_url": "http://localhost/diaspora/peronospora",
     "repo_name": "Peronospora",
-    "repo_homepage": "http://localhost/peronospora",
+    "repo_homepage": "http://localhost/diaspora/peronospora",
     "delete_branch_commit": false
 }

--- a/spec/fixtures/default_payload.json
+++ b/spec/fixtures/default_payload.json
@@ -7,9 +7,9 @@
   "project_id": 15,
   "repository": {
     "name": "Diaspora",
-    "url": "git@example.com:diaspora.git",
+    "url": "git@example.com:diaspora/diaspora.git",
     "description": "",
-    "homepage": "http://example.com/diaspora",
+    "homepage": "http://example.com/diaspora/diaspora",
     "private": true
   },
   "commits": [
@@ -17,7 +17,7 @@
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "message": "Update Catalan translation to e38cb41.",
       "timestamp": "2011-12-12T14:27:31+02:00",
-      "url": "http://example.com/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "url": "http://example.com/diaspora/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
         "name": "John Smith",
         "email": "jsmith@example.com"
@@ -27,7 +27,7 @@
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
       "timestamp": "2012-01-03T23:36:29+02:00",
-      "url": "http://example.com/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "url": "http://example.com/diaspora/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {
         "name": "John Smith the Second",
         "email": "jsmith2@example.com"

--- a/spec/services/flat_keys_hash_spec.rb
+++ b/spec/services/flat_keys_hash_spec.rb
@@ -20,7 +20,7 @@ module GitlabWebHook
     it 'exposes root' do
       repository = subject.to_flat_keys['repository']
       expect(repository.keys.count).to eq(5)
-      expect(repository['url']).to eq('git@example.com:diaspora.git')
+      expect(repository['url']).to eq('git@example.com:diaspora/diaspora.git')
     end
 
     it 'indexes arrays' do

--- a/spec/services/get_build_cause_spec.rb
+++ b/spec/services/get_build_cause_spec.rb
@@ -24,7 +24,7 @@ module GitlabWebHook
         allow(details).to receive(:payload) { true }
         allow(details).to receive(:full_branch_reference) { 'master' }
         allow(details).to receive(:commits_count) { 1 }
-        allow(details).to receive(:commits) { [double(Commit, url: 'http://localhost/peronospora/commits/123456', message: 'fix')] }
+        allow(details).to receive(:commits) { [double(Commit, url: 'http://localhost/diaspora/peronospora/commits/123456', message: 'fix')] }
 
         cause = subject.with(details)
         expect(cause.shortDescription).not_to match('no payload available')

--- a/spec/services/get_parameters_values_spec.rb
+++ b/spec/services/get_parameters_values_spec.rb
@@ -25,7 +25,7 @@ module GitlabWebHook
 
       it 'recognizes nested keys' do
         allow(project).to receive(:get_default_parameters) { [build_parameter('repository.url')] }
-        expect(subject.with(project, details)[0].value).to eq('git@example.com:diaspora.git')
+        expect(subject.with(project, details)[0].value).to eq('git@example.com:diaspora/diaspora.git')
       end
 
       it 'recognizes nested array elements' do

--- a/spec/services/parse_request_spec.rb
+++ b/spec/services/parse_request_spec.rb
@@ -9,7 +9,7 @@ module GitlabWebHook
     context 'with data from params' do
       it 'builds parameters influenced details' do
         details = subject.from(parameters, nil)
-        expect(details.repository_url).to eq('http://localhost/peronospora')
+        expect(details.repository_url).to eq('http://localhost/diaspora/peronospora')
       end
     end
 

--- a/spec/services/parse_request_spec.rb
+++ b/spec/services/parse_request_spec.rb
@@ -16,7 +16,7 @@ module GitlabWebHook
     context 'with data from request' do
       it 'builds payload influenced details' do
         details = subject.from({}, request)
-        expect(details.repository_url).to eq('git@example.com:diaspora.git')
+        expect(details.repository_url).to eq('git@example.com:diaspora/diaspora.git')
       end
     end
 

--- a/spec/values/commit_spec.rb
+++ b/spec/values/commit_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 module GitlabWebHook
   describe Commit do
-    let(:subject) { Commit.new('http://localhost/diaspora/commits/450d0de7532f', 'Update Catalan translation') }
+    let(:subject) { Commit.new('http://localhost/diaspora/diaspora/commits/450d0de7532f', 'Update Catalan translation') }
 
     it 'has commit url' do
       expect(subject).to respond_to(:url)
-      expect(subject.url).to eq('http://localhost/diaspora/commits/450d0de7532f')
+      expect(subject.url).to eq('http://localhost/diaspora/diaspora/commits/450d0de7532f')
     end
 
     it 'has commit message' do

--- a/spec/values/parameters_request_details_spec.rb
+++ b/spec/values/parameters_request_details_spec.rb
@@ -13,7 +13,7 @@ module GitlabWebHook
 
     context 'with repository url' do
       it 'extracts from parameters' do
-        expect(subject.repository_url).to eq('http://localhost/peronospora')
+        expect(subject.repository_url).to eq('http://localhost/diaspora/peronospora')
       end
 
       it 'returns empty when no repository details found' do
@@ -35,7 +35,7 @@ module GitlabWebHook
 
     context 'with repository homepage' do
       it 'extracts from parameters' do
-        expect(subject.repository_homepage).to eq('http://localhost/peronospora')
+        expect(subject.repository_homepage).to eq('http://localhost/diaspora/peronospora')
       end
 
       it 'returns empty when no repository details found' do

--- a/spec/values/payload_request_details_spec.rb
+++ b/spec/values/payload_request_details_spec.rb
@@ -13,7 +13,7 @@ module GitlabWebHook
 
     context 'with repository url' do
       it 'extracts from payload' do
-        expect(subject.repository_url).to eq('git@example.com:diaspora.git')
+        expect(subject.repository_url).to eq('git@example.com:diaspora/diaspora.git')
       end
 
       it 'returns empty when no repository details found' do
@@ -35,7 +35,7 @@ module GitlabWebHook
 
     context 'with repository homepage' do
       it 'extracts from payload' do
-        expect(subject.repository_homepage).to eq('http://example.com/diaspora')
+        expect(subject.repository_homepage).to eq('http://example.com/diaspora/diaspora')
       end
 
       it 'returns empty when no repository details found' do
@@ -70,10 +70,10 @@ module GitlabWebHook
       it 'extracts from payload' do
         expect(subject.commits.size).to eq(2)
 
-        expect(subject.commits[0].url).to eq('http://example.com/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327')
+        expect(subject.commits[0].url).to eq('http://example.com/diaspora/diaspora/commits/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327')
         expect(subject.commits[0].message).to eq('Update Catalan translation to e38cb41.')
 
-        expect(subject.commits[1].url).to eq('http://example.com/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7')
+        expect(subject.commits[1].url).to eq('http://example.com/diaspora/diaspora/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7')
         expect(subject.commits[1].message).to eq('fixed readme')
       end
 

--- a/spec/values/repository_uri_spec.rb
+++ b/spec/values/repository_uri_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 module GitlabWebHook
   describe RepositoryUri do
-    let(:subject) { RepositoryUri.new('http://localhost/diaspora') }
+    let(:subject) { RepositoryUri.new('http://localhost/diaspora/diaspora') }
 
     context 'with attributes' do
       it 'has url' do
-        expect(subject.url).to eq('http://localhost/diaspora')
+        expect(subject.url).to eq('http://localhost/diaspora/diaspora')
       end
 
       it 'has host' do
@@ -26,14 +26,14 @@ module GitlabWebHook
         end
 
         it 'with regular uris' do
-          other = URIish.new('http://localhost/diaspora')
+          other = URIish.new('http://localhost/diaspora/diaspora')
           expect(subject.matches?(other)).to be
         end
       end
 
       context 'it is not matching' do
         it 'when repo uris do not match' do
-          other = URIish.new('http://localhost/other')
+          other = URIish.new('http://localhost/diaspora/other')
           expect(subject.matches?(other)).not_to be
         end
       end

--- a/spec/values/request_details_spec.rb
+++ b/spec/values/request_details_spec.rb
@@ -140,9 +140,9 @@ module GitlabWebHook
 
     context 'with flat payload' do
       details = {
-        repository_url: 'git@example.com:diaspora.git',
+        repository_url: 'git@example.com:diaspora/diaspora.git',
         repository_name: 'Diaspora',
-        repository_homepage: 'http://example.com/diaspora',
+        repository_homepage: 'http://example.com/diaspora/diaspora',
         full_branch_reference: 'refs/heads/master',
         branch: 'master'
       }

--- a/spec/values/scm_data_spec.rb
+++ b/spec/values/scm_data_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 module GitlabWebHook
   describe ScmData do
     let(:details) { double(RequestDetails, repository_name: 'discourse', branch: 'features_meta', safe_branch: 'features_meta') }
-    let(:remote_config) { double(UserRemoteConfig, getUrl: 'http://localhost/diaspora', getName: 'Diaspora', getCredentialsId: 'id') }
+    let(:remote_config) { double(UserRemoteConfig, getUrl: 'http://localhost/diaspora/diaspora', getName: 'Diaspora', getCredentialsId: 'id') }
     let(:source_scm) { double(GitSCM, getScmName: 'git', getUserRemoteConfigs: [remote_config, double(UserRemoteConfig)]).as_null_object }
     let(:subject) { described_class.new(source_scm, details) }
 
     context 'when building' do
       it 'it uses source scm first configuration' do
-        expect(subject.url).to eq('http://localhost/diaspora')
+        expect(subject.url).to eq('http://localhost/diaspora/diaspora')
       end
 
       it 'takes url from source scm configuration' do
-        expect(subject.url).to eq('http://localhost/diaspora')
+        expect(subject.url).to eq('http://localhost/diaspora/diaspora')
       end
 
       it 'takes name from source scm configuration' do


### PR DESCRIPTION
Correct the push event payloads, which are wrong on gitlab documentation, where information about group/namespace is absent. The issue has been already reported there.